### PR TITLE
Backport essence of performance improvement from f1fda99

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -178,18 +178,7 @@ int add_agent()
     do {
         /* Default ID */
         i = MAX_AGENTS + 32512;
-        snprintf(id, 8, "%03d", i);
-        while (!IDExist(id)) {
-            i--;
-            snprintf(id, 8, "%03d", i);
-
-            /* No key present, use id 0 */
-            if (i <= 0) {
-                i = 0;
-                break;
-            }
-        }
-        snprintf(id, 8, "%03d", i + 1);
+        snprintf(id, 8, "%03d", getFirstAvailableId());
 
         /* Get ID */
         printf(ADD_ID, id);

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -29,6 +29,7 @@ int k_import(const char *cmdimport);
 int k_bulkload(const char *cmdbulk);
 
 /* Validation functions */
+int getFirstAvailableId(void);
 int OS_IsValidName(const char *u_name);
 int OS_IsValidID(const char *id);
 int IDExist(const char *id);

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -359,19 +359,7 @@ int k_bulkload(const char *cmdbulk)
         }
 
         /* Default ID */
-        i = MAX_AGENTS + 32512;
-        snprintf(id, 8, "%03d", i);
-        while (!IDExist(id)) {
-            i--;
-            snprintf(id, 8, "%03d", i);
-
-            /* No key present, use id 0 */
-            if (i <= 0) {
-                i = 0;
-                break;
-            }
-        }
-        snprintf(id, 8, "%03d", i + 1);
+        snprintf(id, 8, "%03d", getFirstAvailableId());
 
         if (!OS_IsValidID(id)) {
             printf(INVALID_ID, id);


### PR DESCRIPTION
On OSSEC v2.9.2, the way IDs are selected for new agents is:

* Iterate over a set of sequential IDs, starting at a number much higher
  than the configured MAXAGENTS variable, and working backwards.
* For each of these IDs, scan the entire client.keys file to see if the ID
  exists. If it does, assign ID + 1 as the new ID; if it doesn't exist,
  continue the loop.

This ends up scaling almost quadratically, if we assume that we continue
to increase our MAXAGENTS as we create more and more agents.

Here, we've taken a portion of the f1fda99 patch that maps the IDs in
client.keys *once*, and then finds the first available ID.

We can't backport the entire patch, because:

* It depends on ossec-authd, which doesn't even exist until v3.0.0.
* We're on v2.9.2, and have a bunch of patches that conflict with
  new v3.x changes.